### PR TITLE
Add Llama 3.2 3b instruct to DeepInfra

### DIFF
--- a/providers/deepinfra/provider.json
+++ b/providers/deepinfra/provider.json
@@ -81,6 +81,14 @@
       "throughput": 37,
       "latency": 0.65,
       "updated_at": "2024-12-18"
+    },
+    {
+      "model_id": "llama-3.2-3b-instruct",
+      "price_per_input_token": 0.000000015,
+      "price_per_output_token": 0.000000025,
+      "throughput": 171.5,
+      "latency": 0.24,
+      "updated_at": "2025-1-2"
     }
   ]
 }


### PR DESCRIPTION
## Description
Add Llama 3.2 3b instruct to the list of models DeepInfra supports

References:
Source for statistics: https://openrouter.ai/meta-llama/llama-3.2-3b-instruct

## Type of Change
- [ ] Model Update/Addition
- [ ] Qualitative Metrics (Benchmark Results) Update/Addition
- [X] Provider Update/Addition
- [ ] Other (please specify)

## Checklist

- [X] I've read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [X] My changes are accurate and properly referenced
