### PR TITLE
Add Mistral Small 3 cutoff date

### DIFF
--- a/models/mistral/mistral-small-3/model.json
+++ b/models/mistral/mistral-small-3/model.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "multimodal": false,
   "web_hydrated": false,
-  "knowledge_cutoff": null,
+  "knowledge_cutoff": "2023-10-01",
   "api_ref_link": "https://docs.mistral.ai/api/",
   "playground_link": null,
   "paper_link": null,


### PR DESCRIPTION
## Description

Add Mistral Small 3 cutoff date, from the system prompt available at the model's HuggingFace page.

References:

https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501

## Type of Change

<!-- Mark the appropriate option with an [x] -->

- [x] Model Update/Addition
- [ ] Qualitative Metrics (Benchmark Results) Update/Addition
- [ ] Provider Update/Addition
- [ ] Other (please specify)

## Checklist

- [x] I've read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My changes are accurate and properly referenced
