### PR TITLE
Add Gemini 2.5 Pro

### DIFF
--- a/models/google/gemini-2.5-pro/model.json
+++ b/models/google/gemini-2.5-pro/model.json
@@ -20,7 +20,7 @@
   "training_tokens": null,
   "qualitative_metrics": [
     {
-      "dataset_name": "Humanity's Last Exam",
+      "dataset_name": "Humanity's-Last-Exam",
       "score": 0.188,
       "is_self_reported": true,
       "analysis_method": "Accuracy",
@@ -28,39 +28,39 @@
       "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
     },
     {
-      "dataset_name": "GPQA diamond",
+      "dataset_name": "GPQA-Diamond",
       "score": 0.84,
       "is_self_reported": true,
-      "analysis_method": "Accuracy",
+      "analysis_method": "Pass@1",
       "date_recorded": "2025-03-26",
       "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
     },
     {
-      "dataset_name": "AIME 2025",
+      "dataset_name": "AIME-2025",
       "score": 0.867,
       "is_self_reported": true,
-      "analysis_method": "Accuracy",
+      "analysis_method": "Pass@1",
       "date_recorded": "2025-03-26",
       "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
     },
     {
-      "dataset_name": "AIME 2024",
+      "dataset_name": "AIME-2024",
       "score": 0.92,
       "is_self_reported": true,
-      "analysis_method": "Accuracy",
+      "analysis_method": "Pass@1",
       "date_recorded": "2025-03-26",
       "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
     },
     {
-      "dataset_name": "LiveCodeBench v5",
+      "dataset_name": "LiveCodeBench-v5",
       "score": 0.704,
       "is_self_reported": true,
-      "analysis_method": "Accuracy",
+      "analysis_method": "Pass@1",
       "date_recorded": "2025-03-26",
       "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
     },
     {
-      "dataset_name": "Aider Polyglot",
+      "dataset_name": "Aider-Polyglot",
       "score": 0.729,
       "is_self_reported": false,
       "analysis_method": "Accuracy",
@@ -68,7 +68,7 @@
       "source_link": "https://aider.chat/docs/leaderboards/"
     },
     {
-      "dataset_name": "SWE-bench Verified",
+      "dataset_name": "SWE-bench-verified",
       "score": 0.638,
       "is_self_reported": true,
       "analysis_method": "Accuracy",
@@ -87,12 +87,12 @@
       "dataset_name": "MMMU",
       "score": 0.817,
       "is_self_reported": true,
-      "analysis_method": "Accuracy",
+      "analysis_method": "Pass@1",
       "date_recorded": "2025-03-26",
       "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
     },
     {
-      "dataset_name": "Vibe-Eval (Reka)",
+      "dataset_name": "Vibe-Eval-Reka",
       "score": 0.694,
       "is_self_reported": true,
       "analysis_method": "Accuracy",
@@ -103,12 +103,12 @@
       "dataset_name": "MRCR",
       "score": 0.945,
       "is_self_reported": true,
-      "analysis_method": "Accuracy",
+      "analysis_method": "128k-average",
       "date_recorded": "2025-03-26",
       "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
     },
     {
-      "dataset_name": "Global MMLU (Lite)",
+      "dataset_name": "Global-MMLU-Lite",
       "score": 0.898,
       "is_self_reported": true,
       "analysis_method": "Accuracy",

--- a/models/google/gemini-2.5-pro/model.json
+++ b/models/google/gemini-2.5-pro/model.json
@@ -1,0 +1,119 @@
+{
+  "canonical_model_id": null,
+  "fine_tuned_from_model_id": null,
+  "name": "Gemini 2.5 Pro",
+  "description": "Gemini 2.5 Pro is a state-of-the-art multimodal model optimized for a wide range of reasoning tasks. It can process large amounts of data at once (1M context window).",
+  "release_date": "2025-03-25",
+  "input_context_size": 1048576,
+  "output_context_size": 65536,
+  "license": "Proprietary",
+  "multimodal": true,
+  "web_hydrated": false,
+  "knowledge_cutoff": "2025-01-31",
+  "api_ref_link": "https://ai.google.dev/gemini-api/docs/models?hl=en#gemini-2.5-pro-preview-03-25",
+  "playground_link": "https://aistudio.google.com/?model=gemini-2.5-pro-preview-03-25",
+  "paper_link": null,
+  "scorecard_blog_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/",
+  "repo_link": null,
+  "weights_link": null,
+  "param_count": null,
+  "training_tokens": null,
+  "qualitative_metrics": [
+    {
+      "dataset_name": "Humanity's Last Exam",
+      "score": 0.188,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    },
+    {
+      "dataset_name": "GPQA diamond",
+      "score": 0.84,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    },
+    {
+      "dataset_name": "AIME 2025",
+      "score": 0.867,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    },
+    {
+      "dataset_name": "AIME 2024",
+      "score": 0.92,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    },
+    {
+      "dataset_name": "LiveCodeBench v5",
+      "score": 0.704,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    },
+    {
+      "dataset_name": "Aider Polyglot",
+      "score": 0.729,
+      "is_self_reported": false,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://aider.chat/docs/leaderboards/"
+    },
+    {
+      "dataset_name": "SWE-bench Verified",
+      "score": 0.638,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    },
+    {
+      "dataset_name": "SimpleQA",
+      "score": 0.529,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    },
+    {
+      "dataset_name": "MMMU",
+      "score": 0.817,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    },
+    {
+      "dataset_name": "Vibe-Eval (Reka)",
+      "score": 0.694,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    },
+    {
+      "dataset_name": "MRCR",
+      "score": 0.945,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    },
+    {
+      "dataset_name": "Global MMLU (Lite)",
+      "score": 0.898,
+      "is_self_reported": true,
+      "analysis_method": "Accuracy",
+      "date_recorded": "2025-03-26",
+      "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
+    }
+  ]
+}

--- a/models/google/gemini-2.5-pro/model.json
+++ b/models/google/gemini-2.5-pro/model.json
@@ -28,7 +28,7 @@
       "source_link": "https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/"
     },
     {
-      "dataset_name": "GPQA-Diamond",
+      "dataset_name": "GPQA",
       "score": 0.84,
       "is_self_reported": true,
       "analysis_method": "Pass@1",


### PR DESCRIPTION
## Description

<!-- Briefly describe your changes and add links to the relevant resources -->
This pull request adds a new model configuration for the Gemini 2.5 Pro model by Google to the `models/google/gemini-2.5-pro/model.json` file.

Also addresses issue [#29](https://github.com/JonathanChavezTamales/LLMStats/issues/29)

References:
https://ai.google.dev/gemini-api/docs/models?hl=en#gemini-2.5-pro-preview-03-25
https://deepmind.google/technologies/gemini/pro/

<!-- Add links to the relevant resources -->

## Type of Change

<!-- Mark the appropriate option with an [x] -->

- [x] Model Update/Addition
- [ ] Qualitative Metrics (Benchmark Results) Update/Addition
- [ ] Provider Update/Addition
- [ ] Other (please specify)

## Checklist

- [x] I've read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My changes are accurate and properly referenced
