### PR TITLE
New Phi 4 Models

### DIFF
--- a/models/amazon/nova-micro/model.json
+++ b/models/amazon/nova-micro/model.json
@@ -22,7 +22,7 @@
       "source_link": "https://www.amazon.science/publications/the-amazon-nova-family-of-models-technical-report-and-model-card"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.902,
       "is_self_reported": true,
       "analysis_method": "0-shot",

--- a/models/amazon/nova-pro/model.json
+++ b/models/amazon/nova-pro/model.json
@@ -38,7 +38,7 @@
       "source_link": "https://www.amazon.science/publications/the-amazon-nova-family-of-models-technical-report-and-model-card"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.948,
       "is_self_reported": true,
       "analysis_method": "0-shot Chain-of-Thought",

--- a/models/google/gemma-2-27b-it/model.json
+++ b/models/google/gemma-2-27b-it/model.json
@@ -76,7 +76,7 @@
       "source_link": "https://huggingface.co/blog/gemma2"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.714,
       "is_self_reported": true,
       "analysis_method": "25-shot",

--- a/models/google/gemma-2-9b-it/model.json
+++ b/models/google/gemma-2-9b-it/model.json
@@ -76,7 +76,7 @@
       "source_link": "https://huggingface.co/blog/gemma2"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.684,
       "is_self_reported": true,
       "analysis_method": "25-shot evaluation",

--- a/models/ibm/granite-3.3-8b-base/model.json
+++ b/models/ibm/granite-3.3-8b-base/model.json
@@ -132,7 +132,7 @@
       "source_link": "https://huggingface.co/ibm-granite/granite-3.3-8b-base"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.5084,
       "is_self_reported": true,
       "analysis_method": "Score",

--- a/models/meta/llama-3.2-3b-instruct/model.json
+++ b/models/meta/llama-3.2-3b-instruct/model.json
@@ -68,7 +68,7 @@
       "source_link": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.786,
       "is_self_reported": true,
       "analysis_method": "0-shot, acc",

--- a/models/microsoft/phi-4-mini-reasoning/model.json
+++ b/models/microsoft/phi-4-mini-reasoning/model.json
@@ -1,0 +1,47 @@
+{
+  "canonical_model_id": null,
+  "fine_tuned_from_model_id": null,
+  "name": "Phi 4 Mini Reasoning",
+  "description": "Phi-4-mini-reasoning is designed for multi-step, logic-intensive mathematical problem-solving tasks under memory/compute constrained environments and latency bound scenarios. Some of the use cases include formal proof generation, symbolic computation, advanced word problems, and a wide range of mathematical reasoning scenarios. These models excel at maintaining context across steps, applying structured logic, and delivering accurate, reliable solutions in domains that require deep analytical thinking.",
+  "release_date": "2025-04-30",
+  "input_context_size": 128000,
+  "output_context_size": 32768,
+  "license": "MIT",
+  "multimodal": false,
+  "web_hydrated": false,
+  "knowledge_cutoff": "2025-02-01",
+  "api_ref_link": "https://learn.microsoft.com/en-us/windows/ai/apis/phi-silica?tabs=csharp0,csharp1,csharp2,csharp3",
+  "playground_link": null,
+  "paper_link": "https://arxiv.org/pdf/2504.21233",
+  "scorecard_blog_link": "https://azure.microsoft.com/en-us/blog/one-year-of-phi-small-language-models-making-big-leaps-in-ai/",
+  "repo_link": null,
+  "weights_link": "https://huggingface.co/microsoft/Phi-4-mini-reasoning",
+  "param_count": 3800000000,
+  "training_tokens": 150000000000,
+  "qualitative_metrics": [
+    {
+      "dataset_name": "AIME",
+      "score": 0.575,
+      "is_self_reported": true,
+      "analysis_method": "Standard evaluation",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-reasoning"
+    },
+    {
+      "dataset_name": "MATH-500",
+      "score": 0.946,
+      "is_self_reported": true,
+      "analysis_method": "Standard evaluation",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-reasoning"
+    },
+    {
+      "dataset_name": "GPQA",
+      "score": 0.52,
+      "is_self_reported": true,
+      "analysis_method": "Diamond",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-reasoning"
+    }
+  ]
+}

--- a/models/microsoft/phi-4-mini/model.json
+++ b/models/microsoft/phi-4-mini/model.json
@@ -1,0 +1,159 @@
+{
+  "canonical_model_id": null,
+  "fine_tuned_from_model_id": null,
+  "name": "Phi 4 Mini",
+  "description": "Phi 4 Mini Instruct is a lightweight (3.8B parameters) open model built upon synthetic data and filtered web data, focusing on high-quality reasoning. It supports a 128K token context length and is enhanced for instruction adherence and safety via supervised fine-tuning and direct preference optimization.",
+  "release_date": "2025-02-01",
+  "input_context_size": 128000,
+  "output_context_size": 128000,
+  "license": "MIT",
+  "multimodal": false,
+  "web_hydrated": false,
+  "knowledge_cutoff": "2025-06-01",
+  "api_ref_link": null,
+  "playground_link": null,
+  "paper_link": "https://arxiv.org/pdf/2503.01743",
+  "scorecard_blog_link": "https://azure.microsoft.com/en-us/blog/empowering-innovation-the-next-generation-of-the-phi-family/",
+  "repo_link": null,
+  "weights_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct",
+  "param_count": 3840000000,
+  "training_tokens": 5000000000000,
+  "qualitative_metrics": [
+    {
+      "dataset_name": "Arena Hard",
+      "score": 0.328,
+      "is_self_reported": true,
+      "analysis_method": "Standard evaluation",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "BigBench Hard",
+      "score": 0.704,
+      "is_self_reported": true,
+      "analysis_method": "0-shot, CoT",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "MMLU",
+      "score": 0.673,
+      "is_self_reported": true,
+      "analysis_method": "5-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "MMLU-Pro",
+      "score": 0.528,
+      "is_self_reported": true,
+      "analysis_method": "0-shot, CoT",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "ARC-C",
+      "score": 0.837,
+      "is_self_reported": true,
+      "analysis_method": "10-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "BoolQ",
+      "score": 0.812,
+      "is_self_reported": true,
+      "analysis_method": "2-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "GPQA",
+      "score": 0.252,
+      "is_self_reported": true,
+      "analysis_method": "0-shot, CoT",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "HellaSwag",
+      "score": 0.691,
+      "is_self_reported": true,
+      "analysis_method": "5-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "OpenBookQA",
+      "score": 0.792,
+      "is_self_reported": true,
+      "analysis_method": "10-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "PIQA",
+      "score": 0.776,
+      "is_self_reported": true,
+      "analysis_method": "5-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "Social IQA",
+      "score": 0.725,
+      "is_self_reported": true,
+      "analysis_method": "5-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "TruthfulQA",
+      "score": 0.664,
+      "is_self_reported": true,
+      "analysis_method": "MC2, 10-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "Winogrande",
+      "score": 0.67,
+      "is_self_reported": true,
+      "analysis_method": "5-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "Multilingual MMLU",
+      "score": 0.493,
+      "is_self_reported": true,
+      "analysis_method": "5-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "MGSM",
+      "score": 0.639,
+      "is_self_reported": true,
+      "analysis_method": "5-shot",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "GSM8K",
+      "score": 0.886,
+      "is_self_reported": true,
+      "analysis_method": "8-shot, CoT",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    },
+    {
+      "dataset_name": "MATH",
+      "score": 0.64,
+      "is_self_reported": true,
+      "analysis_method": "0-shot, CoT",
+      "date_recorded": "2025-02-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-mini-instruct"
+    }
+  ]
+}

--- a/models/microsoft/phi-4-reasoning-plus/model.json
+++ b/models/microsoft/phi-4-reasoning-plus/model.json
@@ -1,8 +1,8 @@
 {
   "canonical_model_id": null,
-  "fine_tuned_from_model_id": "microsoft/phi-4",
-  "name": "Phi 4 Reasoning",
-  "description": "Phi-4-reasoning is a state-of-the-art open-weight reasoning model finetuned from Phi-4 using supervised fine-tuning on a dataset of chain-of-thought traces and reinforcement learning. It focuses on math, science, and coding skills.",
+  "fine_tuned_from_model_id": null,
+  "name": "Phi 4 Reasoning Plus",
+  "description": "Phi-4-reasoning-plus is a state-of-the-art open-weight reasoning model finetuned from Phi-4 using supervised fine-tuning and reinforcement learning. It focuses on math, science, and coding skills. This 'plus' version has higher accuracy due to additional RL training but may have higher latency.",
   "release_date": "2025-04-30",
   "input_context_size": 32000,
   "output_context_size": 32000,
@@ -15,53 +15,53 @@
   "paper_link": "https://arxiv.org/abs/2504.21318",
   "scorecard_blog_link": "https://azure.microsoft.com/en-us/blog/one-year-of-phi-small-language-models-making-big-leaps-in-ai/",
   "repo_link": null,
-  "weights_link": "https://huggingface.co/microsoft/Phi-4-reasoning",
+  "weights_link": "https://huggingface.co/microsoft/Phi-4-reasoning-plus",
   "param_count": 14000000000,
   "training_tokens": 16000000000,
   "qualitative_metrics": [
     {
       "dataset_name": "AIME 2024",
-      "score": 0.753,
+      "score": 0.813,
       "is_self_reported": true,
       "analysis_method": "Standard evaluation",
       "date_recorded": "2025-03-01",
-      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning"
+      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning-plus"
     },
     {
       "dataset_name": "AIME 2025",
-      "score": 0.629,
+      "score": 0.78,
       "is_self_reported": true,
       "analysis_method": "Standard evaluation",
       "date_recorded": "2025-03-01",
-      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning"
+      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning-plus"
     },
     {
       "dataset_name": "OmniMath",
-      "score": 0.766,
+      "score": 0.819,
       "is_self_reported": true,
       "analysis_method": "Standard evaluation",
       "date_recorded": "2025-03-01",
-      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning"
+      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning-plus"
     },
     {
       "dataset_name": "GPQA",
-      "score": 0.658,
+      "score": 0.689,
       "is_self_reported": true,
       "analysis_method": "Diamond",
       "date_recorded": "2025-03-01",
-      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning"
+      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning-plus"
     },
     {
       "dataset_name": "LiveCodeBench",
-      "score": 0.538,
+      "score": 0.531,
       "is_self_reported": true,
       "analysis_method": "8/1/24–2/1/25",
       "date_recorded": "2025-03-01",
-      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning"
+      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning-plus"
     },
     {
       "dataset_name": "FlenQA",
-      "score": 0.977,
+      "score": 0.979,
       "is_self_reported": true,
       "analysis_method": "3K-token subset",
       "date_recorded": "2025-03-01",
@@ -69,7 +69,7 @@
     },
     {
       "dataset_name": "IFEval",
-      "score": 0.834,
+      "score": 0.849,
       "is_self_reported": true,
       "analysis_method": "Strict",
       "date_recorded": "2025-03-01",
@@ -77,7 +77,7 @@
     },
     {
       "dataset_name": "Arena Hard",
-      "score": 0.733,
+      "score": 0.79,
       "is_self_reported": true,
       "analysis_method": "Standard evaluation",
       "date_recorded": "2025-03-01",
@@ -85,7 +85,7 @@
     },
     {
       "dataset_name": "HumanEval+",
-      "score": 0.929,
+      "score": 0.923,
       "is_self_reported": true,
       "analysis_method": "Standard evaluation",
       "date_recorded": "2025-03-01",
@@ -93,7 +93,7 @@
     },
     {
       "dataset_name": "MMLU-Pro",
-      "score": 0.743,
+      "score": 0.76,
       "is_self_reported": true,
       "analysis_method": "Standard evaluation",
       "date_recorded": "2025-03-01",
@@ -101,7 +101,7 @@
     },
     {
       "dataset_name": "PhiBench",
-      "score": 0.706,
+      "score": 0.742,
       "is_self_reported": true,
       "analysis_method": "2.21",
       "date_recorded": "2025-03-01",

--- a/models/microsoft/phi-4-reasoning/model.json
+++ b/models/microsoft/phi-4-reasoning/model.json
@@ -1,0 +1,63 @@
+{
+  "canonical_model_id": null,
+  "fine_tuned_from_model_id": "microsoft/phi-4",
+  "name": "Phi 4 Reasoning",
+  "description": "Phi-4-reasoning is a state-of-the-art open-weight reasoning model finetuned from Phi-4 using supervised fine-tuning on a dataset of chain-of-thought traces and reinforcement learning. It focuses on math, science, and coding skills.",
+  "release_date": "2025-04-30",
+  "input_context_size": 32000,
+  "output_context_size": 32000,
+  "license": "MIT",
+  "multimodal": false,
+  "web_hydrated": false,
+  "knowledge_cutoff": "2025-04-01",
+  "api_ref_link": "https://learn.microsoft.com/en-us/windows/ai/apis/phi-silica?tabs=csharp0,csharp1,csharp2,csharp3",
+  "playground_link": null,
+  "paper_link": "https://arxiv.org/abs/2504.21318",
+  "scorecard_blog_link": "https://azure.microsoft.com/en-us/blog/one-year-of-phi-small-language-models-making-big-leaps-in-ai/",
+  "repo_link": null,
+  "weights_link": "https://huggingface.co/microsoft/Phi-4-reasoning",
+  "param_count": 14000000000,
+  "training_tokens": 16000000000,
+  "qualitative_metrics": [
+    {
+      "dataset_name": "AIME 2024",
+      "score": 0.753,
+      "is_self_reported": true,
+      "analysis_method": "Standard evaluation",
+      "date_recorded": "2025-03-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning"
+    },
+    {
+      "dataset_name": "AIME 2025",
+      "score": 0.629,
+      "is_self_reported": true,
+      "analysis_method": "Standard evaluation",
+      "date_recorded": "2025-03-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning"
+    },
+    {
+      "dataset_name": "OmniMath",
+      "score": 0.766,
+      "is_self_reported": true,
+      "analysis_method": "Standard evaluation",
+      "date_recorded": "2025-03-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning"
+    },
+    {
+      "dataset_name": "GPQA",
+      "score": 0.658,
+      "is_self_reported": true,
+      "analysis_method": "Diamond",
+      "date_recorded": "2025-03-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning"
+    },
+    {
+      "dataset_name": "LiveCodeBench",
+      "score": 0.538,
+      "is_self_reported": true,
+      "analysis_method": "8/1/24–2/1/25",
+      "date_recorded": "2025-03-01",
+      "source_link": "https://huggingface.co/microsoft/Phi-4-reasoning"
+    }
+  ]
+}

--- a/models/mistral/mistral-small-24b-base-2501/model.json
+++ b/models/mistral/mistral-small-24b-base-2501/model.json
@@ -52,7 +52,7 @@
       "source_link": "https://huggingface.co/mistralai/Mistral-Small-24B-Base-2501"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.9129,
       "is_self_reported": true,
       "analysis_method": "0-shot",

--- a/models/qwen/qwen-2.5-14b-instruct/model.json
+++ b/models/qwen/qwen-2.5-14b-instruct/model.json
@@ -52,7 +52,7 @@
       "source_link": "https://qwenlm.github.io/blog/qwen2.5-llm/"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.673,
       "is_self_reported": true,
       "analysis_method": "ARC-C benchmark evaluation",

--- a/models/qwen/qwen-2.5-32b-instruct/model.json
+++ b/models/qwen/qwen-2.5-32b-instruct/model.json
@@ -52,7 +52,7 @@
       "source_link": "https://qwenlm.github.io/blog/qwen2.5-llm/"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.704,
       "is_self_reported": true,
       "analysis_method": "ARC-C benchmark evaluation",

--- a/models/qwen/qwen-2.5-coder-32b-instruct/model.json
+++ b/models/qwen/qwen-2.5-coder-32b-instruct/model.json
@@ -60,7 +60,7 @@
       "source_link": "https://arxiv.org/abs/2409.12186"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.705,
       "is_self_reported": true,
       "analysis_method": "accuracy",

--- a/models/qwen/qwen-2.5-coder-7b-instruct/model.json
+++ b/models/qwen/qwen-2.5-coder-7b-instruct/model.json
@@ -100,7 +100,7 @@
       "source_link": "https://arxiv.org/abs/2409.12186"
     },
     {
-      "dataset_name": "ARC Challenge",
+      "dataset_name": "ARC-C",
       "score": 0.609,
       "is_self_reported": true,
       "analysis_method": "accuracy",


### PR DESCRIPTION
## Description

Adds the following models:
- `phi-4-mini-instruct`
- `phi-4-mini-reasoning`
- `phi-4-reasoning`
- `phi-4-reasoning-plus`

Solves https://github.com/JonathanChavezTamales/LLMStats/issues/43

## Type of Change

<!-- Mark the appropriate option with an [x] -->

- [x] Model Update/Addition
- [x] Qualitative Metrics (Benchmark Results) Update/Addition
- [ ] Provider Update/Addition
- [ ] Other (please specify)

## Checklist

- [x] I've read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My changes are accurate and properly referenced
